### PR TITLE
[TOB] DEV-3732: ID-2

### DIFF
--- a/src/automata_pccs/shared/AutomataDaoBase.sol
+++ b/src/automata_pccs/shared/AutomataDaoBase.sol
@@ -5,6 +5,9 @@ import {AutomataDaoStorage} from "./AutomataDaoStorage.sol";
 import {DaoBase} from "../../bases/DaoBase.sol";
 
 abstract contract AutomataDaoBase is DaoBase {
+
+    // 953769d0
+    error Unauthorized_Caller(address caller);
     
     /**
      * @notice overridden the default method to check caller authorization
@@ -23,6 +26,8 @@ abstract contract AutomataDaoBase is DaoBase {
     {
         if (_callerIsAuthorized()) {
             data = super._onFetchDataFromResolver(key, hash);
+        } else {
+            revert Unauthorized_Caller(msg.sender);
         }
     }
 

--- a/src/bases/EnclaveIdentityDao.sol
+++ b/src/bases/EnclaveIdentityDao.sol
@@ -142,7 +142,7 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
 
         // make sure new collateral is "newer"
         key = ENCLAVE_ID_KEY(id, version);
-        bytes memory existingData = _onFetchDataFromResolver(key, false);
+        bytes memory existingData = _fetchDataFromResolver(key, false);
         if (existingData.length > 0) {
             (IdentityObj memory existingIdentity, , ) =
                 abi.decode(existingData, (IdentityObj, string, bytes));

--- a/test/pcs/AutomataPcsDaoTest.t.sol
+++ b/test/pcs/AutomataPcsDaoTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../pcs/PCSSetupBase.t.sol";
-import {AutomataPckDao} from "../../src/automata_pccs/AutomataPckDao.sol";
+import {AutomataDaoBase} from "../../src/automata_pccs/shared/AutomataDaoBase.sol";
 
 contract AutomataPcsDaoTest is PCSSetupBase {
     function testPcsGetCertsAndRootCrl() public readAsAuthorizedCaller {
@@ -15,7 +15,9 @@ contract AutomataPcsDaoTest is PCSSetupBase {
     }
 
     function testUnauthorizedRead() public {
-        vm.expectRevert(abi.encodeWithSelector(PcsDao.Missing_Certificate.selector, CA.ROOT));
+        (, address caller, ) = vm.readCallers();
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(AutomataDaoBase.Unauthorized_Caller.selector, caller));
         pcs.getCertificateById(CA.ROOT);
     }
 


### PR DESCRIPTION
The `_onFetchDataFromResolver()` method now explicitly returns an `Unauthorized_Caller()` error for unauthorized reads. 