### PR TITLE
[TOB] DEV-3733: ID-3

### DIFF
--- a/script/automata/ConfigAutomataDao.s.sol
+++ b/script/automata/ConfigAutomataDao.s.sol
@@ -23,11 +23,11 @@ contract ConfigAutomataDao is Script {
     address enclaveIdentityHelper = vm.envAddress("ENCLAVE_IDENTITY_HELPER");
     address fmspcTcbHelper = vm.envAddress("FMSPC_TCB_HELPER");
 
-    function updateStorageDao() public {
+    function grantDao(address dao) public {
         vm.broadcast(privateKey);
 
         AutomataDaoStorage pccsStorage = AutomataDaoStorage(pccsStorageAddr);
-        pccsStorage.updateDao(pcsDaoAddr, pckDaoAddr, fmspcTcbDaoAddr, enclaveIdDaoAddr);
+        pccsStorage.grantDao(dao);
     }
 
     function revokeDao(address dao) public {

--- a/script/automata/DeployAutomataDao.s.sol
+++ b/script/automata/DeployAutomataDao.s.sol
@@ -53,7 +53,11 @@ contract DeployAutomataDao is P256Configuration {
             new AutomataFmspcTcbDao(address(pccsStorage), simulateVerify(), address(pcsDao), fmspcTcbHelper, x509);
         console.log("AutomataFmspcTcbDao deployed at: ", address(fmspcTcbDao));
 
-        pccsStorage.updateDao(address(pcsDao), address(pckDao), address(fmspcTcbDao), address(enclaveIdDao));
+        // grants the DAOs permission to write to storage
+        pccsStorage.grantDao(address(pcsDao));
+        pccsStorage.grantDao(address(pckDao));
+        pccsStorage.grantDao(address(enclaveIdDao));
+        pccsStorage.grantDao(address(fmspcTcbDao));
     }
 
     function deployStorage() public broadcastKey(privateKey) {

--- a/src/automata_pccs/shared/AutomataDaoStorage.sol
+++ b/src/automata_pccs/shared/AutomataDaoStorage.sol
@@ -17,6 +17,9 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
     mapping(address => bool) _authorized_readers;
     mapping(bytes32 attId => bytes collateral) _db;
 
+    event SetAuthorizedWriter(address caller, bool authorized);
+    event SetAuthorizedReader(address caller, bool authorized);
+
     modifier onlyDao(address dao) {
         require(_authorized_writers[dao], "FORBIDDEN");
         _;
@@ -26,7 +29,7 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
         _initializeOwner(msg.sender);
 
         // adding address(0) as an authorized_reader to allow eth_call
-        _authorized_readers[address(0)] = true;
+        _setAuthorizedReader(address(0), true);
     }
 
     function isAuthorizedCaller(address caller) external view returns (bool) {
@@ -34,7 +37,7 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
     }
 
     function setCallerAuthorization(address caller, bool authorized) external onlyOwner {
-        _authorized_readers[caller] = authorized;
+        _setAuthorizedReader(caller, authorized);
     }
 
     function pauseCallerRestriction() external onlyOwner whenNotPaused {
@@ -46,11 +49,11 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
     }
 
     function grantDao(address granted) external onlyOwner {
-        _authorized_writers[granted] = true;
+        _setAuthorizedWriter(granted, true);
     }
 
     function revokeDao(address revoked) external onlyOwner {
-        _authorized_writers[revoked] = false;
+        _setAuthorizedWriter(revoked, false);
     }
 
     function collateralPointer(bytes32 key) external pure override returns (bytes32 collateralAttId) {
@@ -97,6 +100,16 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
     function _computeAttestationId(bytes32 key, bool hash) private pure returns (bytes32 attestationId) {
         bytes32 magic = hash ? HASH_ATTESTATION_MAGIC : DATA_ATTESTATION_MAGIC;
         attestationId = keccak256(abi.encodePacked(magic, key));
+    }
+
+    function _setAuthorizedWriter(address caller, bool authorized) private {
+        _authorized_writers[caller] = authorized;
+        emit SetAuthorizedWriter(caller, authorized);
+    }
+
+    function _setAuthorizedReader(address caller, bool authorized) private {
+        _authorized_readers[caller] = authorized;
+        emit SetAuthorizedReader(caller, authorized);
     }
 
     /// TCB Management

--- a/src/automata_pccs/shared/AutomataDaoStorage.sol
+++ b/src/automata_pccs/shared/AutomataDaoStorage.sol
@@ -45,11 +45,8 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
         _unpause();
     }
 
-    function updateDao(address _pcsDao, address _pckDao, address _fmspcTcbDao, address _enclaveIdDao)
-        external
-        onlyOwner
-    {
-        _updateDao(_pcsDao, _pckDao, _fmspcTcbDao, _enclaveIdDao);
+    function grantDao(address granted) external onlyOwner {
+        _authorized_writers[granted] = true;
     }
 
     function revokeDao(address revoked) external onlyOwner {
@@ -91,13 +88,6 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
             hashAttestationid = _computeAttestationId(key, true);
             _db[hashAttestationid] = abi.encodePacked(attDataHash);
         }
-    }
-
-    function _updateDao(address _pcsDao, address _pckDao, address _fmspcTcbDao, address _enclaveIdDao) private {
-        _authorized_writers[_pcsDao] = true;
-        _authorized_writers[_pckDao] = true;
-        _authorized_writers[_fmspcTcbDao] = true;
-        _authorized_writers[_enclaveIdDao] = true;
     }
 
     /// Attestation ID Computation

--- a/test/TestSetupBase.t.sol
+++ b/test/TestSetupBase.t.sol
@@ -66,7 +66,11 @@ abstract contract TestSetupBase is Test {
         pck =
             new AutomataPckDao(address(pccsStorage), P256_VERIFIER, address(pcs), address(x509Lib), address(x509CrlLib));
 
-        pccsStorage.updateDao(address(pcs), address(pck), address(fmspcTcbDao), address(enclaveIdDao));
+        // grants dao permissions to write to the storage
+        pccsStorage.grantDao(address(pcs));
+        pccsStorage.grantDao(address(pck));
+        pccsStorage.grantDao(address(fmspcTcbDao));
+        pccsStorage.grantDao(address(enclaveIdDao));
 
         // grants admin address permission to read collaterals
         pccsStorage.setCallerAuthorization(admin, true);

--- a/test/tcb/TCBMockTest.t.sol
+++ b/test/tcb/TCBMockTest.t.sol
@@ -20,7 +20,7 @@ contract TcbMockTest is PCSSetupBase, TCBConstants {
         );
 
         vm.prank(admin);
-        pccsStorage.updateDao(address(pcs), address(pck), address(tcb), address(enclaveIdDao));
+        pccsStorage.grantDao(address(tcb));
     }
 
     function testMockFmspcTcbTdxV3() public {


### PR DESCRIPTION
The behavior of granting and revoking daos for write permission to `AutomataDaoStorage` should be consistent.

A batched permission granting all DAOs write access can be simply done with `forge script`.