### PR TITLE
Typos fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Our DAO implementation can be found in the [`automata_pccs`](./src/automata_pccs
 
 ---
 
-### #BUIDL 🛠️
+### #BUILD 🛠️
 
 - Install [Foundry](https://book.getfoundry.sh/getting-started/installation)
 


### PR DESCRIPTION
### Changes

1. **File:** `/README.md`
    - Fixed `BUIDL` to `BUILD` (Line 168)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.