### PR TITLE
[TOB] DEV-3794: Timestamp Attestations for Collaterals

### DIFF
--- a/src/automata_pccs/AutomataEnclaveIdentityDao.sol
+++ b/src/automata_pccs/AutomataEnclaveIdentityDao.sol
@@ -26,7 +26,7 @@ contract AutomataEnclaveIdentityDao is AutomataDaoBase, EnclaveIdentityDao {
 
     function _loadEnclaveIdentityIssueEvaluation(bytes32 key) internal view override returns (uint64 issueDateTimestamp, uint64 nextUpdateTimestamp, uint32 evaluationDataNumber) {
         bytes32 tcbIssueEvaluationKey = _computeIssueEvaluationKey(key);
-        bytes memory data = resolver.readAttestation(resolver.collateralPointer(tcbIssueEvaluationKey));
+        bytes memory data = _fetchDataFromResolver(tcbIssueEvaluationKey, false);
         if (data.length > 0) {
             (uint256 slot) = abi.decode(data, (uint256));
             issueDateTimestamp = uint64(slot >> 192);

--- a/src/automata_pccs/AutomataEnclaveIdentityDao.sol
+++ b/src/automata_pccs/AutomataEnclaveIdentityDao.sol
@@ -17,4 +17,25 @@ contract AutomataEnclaveIdentityDao is AutomataDaoBase, EnclaveIdentityDao {
     {
         data = super._onFetchDataFromResolver(key, hash);
     }
+
+    function _storeEnclaveIdentityIssueEvaluation(bytes32 key, uint64 issueDateTimestamp, uint64 nextUpdateTimestamp, uint32 evaluationDataNumber) internal override {
+        bytes32 tcbIssueEvaluationKey = _computeIssueEvaluationKey(key);
+        uint256 slot = (uint256(issueDateTimestamp) << 192) | (uint256(nextUpdateTimestamp) << 128) | evaluationDataNumber;
+        resolver.attest(tcbIssueEvaluationKey, abi.encode(slot), bytes32(0));
+    }
+
+    function _loadEnclaveIdentityIssueEvaluation(bytes32 key) internal view override returns (uint64 issueDateTimestamp, uint64 nextUpdateTimestamp, uint32 evaluationDataNumber) {
+        bytes32 tcbIssueEvaluationKey = _computeIssueEvaluationKey(key);
+        bytes memory data = resolver.readAttestation(resolver.collateralPointer(tcbIssueEvaluationKey));
+        if (data.length > 0) {
+            (uint256 slot) = abi.decode(data, (uint256));
+            issueDateTimestamp = uint64(slot >> 192);
+            nextUpdateTimestamp = uint64(slot >> 128);
+            evaluationDataNumber = uint32(slot);
+        }
+    }
+
+    function _computeIssueEvaluationKey(bytes32 key) private pure returns (bytes32 ret) {
+        ret = keccak256(abi.encodePacked(key, "identityIssueEvaluation"));
+    }
 }

--- a/src/automata_pccs/AutomataFmspcTcbDao.sol
+++ b/src/automata_pccs/AutomataFmspcTcbDao.sol
@@ -34,7 +34,7 @@ contract AutomataFmspcTcbDao is AutomataDaoBase, FmspcTcbDao {
     /// @dev we will have to come up with hacky low-level storage reads
     function _loadTcbInfoIssueEvaluation(bytes32 tcbKey) internal view override returns (uint64 issueDateTimestamp, uint64 nextUpdateTimestamp, uint32 evaluationDataNumber) {
         bytes32 tcbIssueEvaluationKey = _computeTcbIssueEvaluationKey(tcbKey);
-        bytes memory data = resolver.readAttestation(resolver.collateralPointer(tcbIssueEvaluationKey));
+        bytes memory data = _fetchDataFromResolver(tcbIssueEvaluationKey, false);
         if (data.length > 0) {
             (uint256 slot) = abi.decode(data, (uint256));
             issueDateTimestamp = uint64(slot >> 192);

--- a/src/automata_pccs/AutomataFmspcTcbDao.sol
+++ b/src/automata_pccs/AutomataFmspcTcbDao.sol
@@ -18,25 +18,27 @@ contract AutomataFmspcTcbDao is AutomataDaoBase, FmspcTcbDao {
         data = super._onFetchDataFromResolver(key, hash);
     }
 
-    /// @dev submit tcb issue date timestamp and evaluation data number as a separate attestation
+    /// @dev submit tcb timestamps and evaluation data number as a separate attestation
+    /// @dev issueDateTimestamp (64 bytes) | nextUpdateTimestamp (64 bytes) | evaluationDataNumber (128 bytes)
     /// TEMP: it is not the most efficient approach, since it's storing duplicate data
     /// @dev if i could extract the required info directly from the attestation,
     /// this method will no longer be needed
     /// @dev this is a good TODO for future optimization
-    function _storeTcbInfoIssueEvaluation(bytes32 tcbKey, uint64 issueDateTimestamp, uint32 evaluationDataNumber) internal override {
+    function _storeTcbInfoIssueEvaluation(bytes32 tcbKey, uint64 issueDateTimestamp, uint64 nextUpdateTimestamp, uint32 evaluationDataNumber) internal override {
         bytes32 tcbIssueEvaluationKey = _computeTcbIssueEvaluationKey(tcbKey);
-        uint256 slot = (uint256(issueDateTimestamp) << 128) | evaluationDataNumber;
+        uint256 slot = (uint256(issueDateTimestamp) << 192) | (uint256(nextUpdateTimestamp) << 128) | evaluationDataNumber;
         resolver.attest(tcbIssueEvaluationKey, abi.encode(slot), bytes32(0));
     }
 
     /// TEMP it just reads from the separate attestation for now
     /// @dev we will have to come up with hacky low-level storage reads
-    function _loadTcbInfoIssueEvaluation(bytes32 tcbKey) internal view override returns (uint64 issueDateTimestamp, uint32 evaluationDataNumber) {
+    function _loadTcbInfoIssueEvaluation(bytes32 tcbKey) internal view override returns (uint64 issueDateTimestamp, uint64 nextUpdateTimestamp, uint32 evaluationDataNumber) {
         bytes32 tcbIssueEvaluationKey = _computeTcbIssueEvaluationKey(tcbKey);
         bytes memory data = resolver.readAttestation(resolver.collateralPointer(tcbIssueEvaluationKey));
         if (data.length > 0) {
             (uint256 slot) = abi.decode(data, (uint256));
-            issueDateTimestamp = uint64(slot >> 128);
+            issueDateTimestamp = uint64(slot >> 192);
+            nextUpdateTimestamp = uint64(slot >> 128);
             evaluationDataNumber = uint32(slot);
         }
     }

--- a/src/automata_pccs/AutomataPckDao.sol
+++ b/src/automata_pccs/AutomataPckDao.sol
@@ -48,7 +48,7 @@ contract AutomataPckDao is AutomataDaoBase, PckDao {
 
     function _loadPckValidity(bytes32 key) internal view override returns (uint64 notValidBefore, uint64 notValidAfter) {
         bytes32 pckValidityKey = _computePckValidityKey(key);
-        bytes memory data = resolver.readAttestation(resolver.collateralPointer(pckValidityKey));
+        bytes memory data = _fetchDataFromResolver(pckValidityKey, false);
         if (data.length > 0) {
             (uint256 slot) = abi.decode(data, (uint256));
             notValidBefore = uint64(slot >> 64);

--- a/src/automata_pccs/AutomataPckDao.sol
+++ b/src/automata_pccs/AutomataPckDao.sol
@@ -39,4 +39,24 @@ contract AutomataPckDao is AutomataDaoBase, PckDao {
     function _tcbrToTcbmMapping(bytes32 tcbMappingKey) internal view override returns (bytes18 tcbm) {
         tcbm = AutomataDaoStorage(address(resolver)).getTcbm(tcbMappingKey);
     }
+
+    function _storePckValidity(bytes32 key, uint64 notValidBefore, uint64 notValidAfter) internal override {
+        bytes32 pckValidityKey = _computePckValidityKey(key);
+        uint256 slot = (uint256(notValidBefore) << 64) | notValidAfter;
+        resolver.attest(pckValidityKey, abi.encode(slot), bytes32(0));
+    }
+
+    function _loadPckValidity(bytes32 key) internal view override returns (uint64 notValidBefore, uint64 notValidAfter) {
+        bytes32 pckValidityKey = _computePckValidityKey(key);
+        bytes memory data = resolver.readAttestation(resolver.collateralPointer(pckValidityKey));
+        if (data.length > 0) {
+            (uint256 slot) = abi.decode(data, (uint256));
+            notValidBefore = uint64(slot >> 64);
+            notValidAfter = uint64(slot);
+        }
+    }
+
+    function _computePckValidityKey(bytes32 key) private pure returns (bytes32 ret) {
+        ret = keccak256(abi.encodePacked(key, "pckValidity"));
+    }
 }

--- a/src/automata_pccs/AutomataPcsDao.sol
+++ b/src/automata_pccs/AutomataPcsDao.sol
@@ -24,7 +24,7 @@ contract AutomataPcsDao is AutomataDaoBase, PcsDao {
 
     function _loadPcsValidity(bytes32 key) internal view override returns (uint64 notValidBefore, uint64 notValidAfter) {
         bytes32 pcsValidityKey = _computePcsValidityKey(key);
-        bytes memory data = resolver.readAttestation(resolver.collateralPointer(pcsValidityKey));
+        bytes memory data = _fetchDataFromResolver(pcsValidityKey, false);
         if (data.length > 0) {
             (uint256 slot) = abi.decode(data, (uint256));
             notValidBefore = uint64(slot >> 64);

--- a/src/automata_pccs/AutomataPcsDao.sol
+++ b/src/automata_pccs/AutomataPcsDao.sol
@@ -15,4 +15,24 @@ contract AutomataPcsDao is AutomataDaoBase, PcsDao {
     {
         data = super._onFetchDataFromResolver(key, hash);
     }
+
+    function _storePcsValidity(bytes32 key, uint64 notValidBefore, uint64 notValidAfter) internal override {
+        bytes32 pcsValidityKey = _computePcsValidityKey(key);
+        uint256 slot = (uint256(notValidBefore) << 64) | notValidAfter;
+        resolver.attest(pcsValidityKey, abi.encode(slot), bytes32(0));
+    }
+
+    function _loadPcsValidity(bytes32 key) internal view override returns (uint64 notValidBefore, uint64 notValidAfter) {
+        bytes32 pcsValidityKey = _computePcsValidityKey(key);
+        bytes memory data = resolver.readAttestation(resolver.collateralPointer(pcsValidityKey));
+        if (data.length > 0) {
+            (uint256 slot) = abi.decode(data, (uint256));
+            notValidBefore = uint64(slot >> 64);
+            notValidAfter = uint64(slot);
+        }
+    }
+
+    function _computePcsValidityKey(bytes32 key) private pure returns (bytes32 ret) {
+        ret = keccak256(abi.encodePacked(key, "pcsValidity"));
+    }
 }

--- a/src/bases/DaoBase.sol
+++ b/src/bases/DaoBase.sol
@@ -17,6 +17,14 @@ abstract contract DaoBase {
     }
 
     /**
+     * @dev must override this method to fetch the validity timestamp range for the specified collateral
+     * @param key - mapped to a collateral as defined by individual data access objects (DAOs)
+     * @return the timestamp that the collateral is being issued
+     * @return the timestamp that the collateral expires and must be re-issued
+     */
+    function getCollateralValidity(bytes32 key) external view virtual returns (uint64, uint64);
+
+    /**
      * @notice getter logic to retrieve attested data from the Resolver
      * @param key - mapped to a collateral as defined by individual data access objects (DAOs)
      */

--- a/src/bases/EnclaveIdentityDao.sol
+++ b/src/bases/EnclaveIdentityDao.sol
@@ -48,6 +48,10 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
         EnclaveIdentityLib = EnclaveIdentityHelper(_enclaveIdentityHelper);
     }
 
+    function getCollateralValidity(bytes32 key) external view override returns (uint64 issueDateTimestamp, uint64 nextUpdateTimestamp) {
+        (issueDateTimestamp, nextUpdateTimestamp, ) = _loadEnclaveIdentityIssueEvaluation(key);
+    }
+
     /**
      * @notice computes the key that is mapped to the collateral attestation ID
      * NOTE: the "version" indicated here is taken from the input parameter (e.g. v3 vs v4);
@@ -126,7 +130,7 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
         uint256 id,
         uint256 version,
         EnclaveIdentityJsonObj calldata enclaveIdentityObj
-    ) private view returns (bytes32 key, bytes memory reqData) {
+    ) private returns (bytes32 key, bytes memory reqData) {
         IdentityObj memory identity = EnclaveIdentityLib.parseIdentityString(enclaveIdentityObj.identityStr);
         if (id != uint256(identity.id)) {
             revert Enclave_Id_Mismatch();
@@ -142,16 +146,15 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
 
         // make sure new collateral is "newer"
         key = ENCLAVE_ID_KEY(id, version);
-        bytes memory existingData = _onFetchDataFromResolver(key, false);
-        if (existingData.length > 0) {
-            (IdentityObj memory existingIdentity, , ) =
-                abi.decode(existingData, (IdentityObj, string, bytes));
-            bool outOfDate = existingIdentity.tcbEvaluationDataNumber > identity.tcbEvaluationDataNumber ||
-                existingIdentity.issueDateTimestamp > identity.issueDateTimestamp;
-            if (outOfDate) {
-                revert Enclave_Id_Out_Of_Date();
-            }
+        (uint64 existingIssueDateTimestamp, , uint64 existingEvaluationDataNumber) = _loadEnclaveIdentityIssueEvaluation(key);
+        bool outOfDate = existingEvaluationDataNumber > identity.tcbEvaluationDataNumber ||
+            existingIssueDateTimestamp > identity.issueDateTimestamp;
+        if (outOfDate) {
+            revert Enclave_Id_Out_Of_Date();
         }
+
+        // attest timestamp
+        _storeEnclaveIdentityIssueEvaluation(key, identity.issueDateTimestamp, identity.nextUpdateTimestamp, identity.tcbEvaluationDataNumber);
 
         reqData = abi.encode(identity, enclaveIdentityObj.identityStr, enclaveIdentityObj.signature);
     }
@@ -170,4 +173,14 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
             revert Invalid_TCB_Cert_Signature();
         }
     }
+
+    /// @dev for the time being, we will require a method to "cache" the issuance timestamp
+    /// @dev and the evaluation data number
+    /// @dev this reduces the amount of data to read, when performing rollback check
+    /// @dev which also allows any caller to check expiration of the Enclave Identity before loading the entire data
+    /// @dev the functions defined below can be overriden by the inheriting contract
+
+    function _storeEnclaveIdentityIssueEvaluation(bytes32 tcbKey, uint64 issueDateTimestamp, uint64 nextUpdateTimestamp, uint32 evaluationDataNumber) internal virtual;
+
+    function _loadEnclaveIdentityIssueEvaluation(bytes32 tcbKey) internal view virtual returns (uint64 issueDateTimestamp, uint64 nextUpdateTimestamp, uint32 evaluationDataNumber);
 }

--- a/src/bases/FmspcTcbDao.sol
+++ b/src/bases/FmspcTcbDao.sol
@@ -58,6 +58,13 @@ abstract contract FmspcTcbDao is DaoBase, SigVerifyBase {
         FmspcTcbLib = FmspcTcbHelper(_fmspcHelper);
     }
 
+    function getCollateralValidity(bytes32 key) external view override returns (
+        uint64 issueDateTimestamp,
+        uint64 nextUpdateTimestamp
+    ) {
+        (issueDateTimestamp, nextUpdateTimestamp, ) = _loadTcbInfoIssueEvaluation(key);
+    }
+
     /**
      * @notice computes the key that is mapped to the collateral attestation ID
      * @return key = keccak256(type ++ FMSPC ++ version)

--- a/src/bases/PckDao.sol
+++ b/src/bases/PckDao.sol
@@ -99,6 +99,13 @@ abstract contract PckDao is DaoBase, SigVerifyBase {
         key = keccak256(abi.encodePacked(TCB_MAPPING_MAGIC, qeid, pceid, platformCpuSvn, platformPceSvn));
     }
 
+    function getCollateralValidity(bytes32 key) external view override returns (
+        uint64 notValidBefore, 
+        uint64 notValidAfter
+    ) {
+        (notValidBefore, notValidAfter) = _loadPckValidity(key);
+    }
+
     /**
      * @notice Section 4.2.2 (getCert(qe_id, cpu_svn, pce_svn, pce_id))
      */
@@ -175,7 +182,11 @@ abstract contract PckDao is DaoBase, SigVerifyBase {
         bytes calldata cert
     ) external pckCACheck(ca) returns (bytes32 attestationId) {
         (bytes16 qeidBytes, bytes2 pceidBytes,,, bytes18 tcbmBytes) = _parseStringInputs(qeid, pceid, "", "", tcbm);
-        (bytes32 hash, bytes32 key) = _validatePck(ca, cert, qeidBytes, pceidBytes, tcbmBytes);
+        (bytes32 hash, bytes32 key, X509CertObj memory pck) = _validatePck(ca, cert, qeidBytes, pceidBytes, tcbmBytes);
+        
+        // attest timestamp
+        _storePckValidity(key, uint64(pck.validityNotBefore), uint64(pck.validityNotAfter));
+        
         attestationId = _attestPck(cert, hash, key);
         _upsertTcbm(qeidBytes, pceidBytes, tcbmBytes);
 
@@ -274,8 +285,8 @@ abstract contract PckDao is DaoBase, SigVerifyBase {
      */
     function _getAllTcbs(bytes16 qeidBytes, bytes2 pceidBytes) internal view virtual returns (bytes18[] memory tcbms);
 
-    function _validatePck(CA ca, bytes memory der, bytes16 qeid, bytes2 pceid, bytes18 tcbm) internal view returns (bytes32 hash, bytes32 key) {
-        X509CertObj memory pck = pckLib.parseX509DER(der);
+    function _validatePck(CA ca, bytes memory der, bytes16 qeid, bytes2 pceid, bytes18 tcbm) internal view returns (bytes32 hash, bytes32 key, X509CertObj memory pck) {
+        pck = pckLib.parseX509DER(der);
         
         // Step 0: Check whether the pck has expired
         bool notExpired = block.timestamp > pck.validityNotBefore && block.timestamp < pck.validityNotAfter;
@@ -288,13 +299,10 @@ abstract contract PckDao is DaoBase, SigVerifyBase {
 
         // Step 1: Rollback prevention: new certificate should not have an issued date
         // that is older than the existing certificate
-        bytes memory existingData = _fetchDataFromResolver(key, false);
-        if (existingData.length > 0) {
-            (uint256 existingCertNotValidBefore, ) = pckLib.getCertValidity(existingData);
-            bool outOfDate = existingCertNotValidBefore > pck.validityNotBefore;
-            if (outOfDate) {
-                revert Pck_Out_Of_Date();
-            }
+        (uint64 existingCertNotValidBefore, ) = _loadPckValidity(key);
+        bool outOfDate = existingCertNotValidBefore > pck.validityNotBefore;
+        if (outOfDate) {
+            revert Pck_Out_Of_Date();
         }
 
         // Step 2: Check Issuer and Subject names
@@ -398,4 +406,11 @@ abstract contract PckDao is DaoBase, SigVerifyBase {
             tcbmBytes = bytes18(uint144(_parseUintFromHex(tcbm)));
         }
     }
+
+    function _storePckValidity(bytes32 key, uint64 notValidBefore, uint64 notValidAfter) internal virtual;
+
+    function _loadPckValidity(bytes32 key) internal view virtual returns (
+        uint64 notValidBefore,
+        uint64 notValidAfter
+    );
 }

--- a/src/bases/PcsDao.sol
+++ b/src/bases/PcsDao.sol
@@ -74,6 +74,13 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
         crlLib = X509CRLHelper(_crl);
     }
 
+    function getCollateralValidity(bytes32 key) external view override returns (
+        uint64 notValidBefore, 
+        uint64 notValidAfter
+    ) {
+        (notValidBefore, notValidAfter) = _loadPcsValidity(key);
+    }
+
     function PCS_KEY(CA ca, bool isCrl) public pure returns (bytes32 key) {
         key = keccak256(abi.encodePacked(PCS_MAGIC, uint8(ca), isCrl));
     }
@@ -106,7 +113,11 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
      * @param cert the DER-encoded certificate
      */
     function upsertPcsCertificates(CA ca, bytes calldata cert) external returns (bytes32 attestationId) {
-        (bytes32 hash, bytes32 key) = _validatePcsCert(ca, cert);
+        (bytes32 hash, bytes32 key, X509CertObj memory parsedX509Cert) = _validatePcsCert(ca, cert);
+        
+        // attest validity
+        _storePcsValidity(key, uint64(parsedX509Cert.validityNotBefore), uint64(parsedX509Cert.validityNotAfter));
+        
         attestationId = _attestPcs(cert, hash, key);
 
         emit UpsertedPCSCollateral(ca, false);
@@ -141,15 +152,19 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
     }
 
     function _upsertPcsCrl(CA ca, bytes calldata crl) private returns (bytes32 attestationId) {
-        (bytes32 hash, bytes32 key) = _validatePcsCrl(ca, crl);
+        (bytes32 hash, bytes32 key, X509CRLObj memory currentCrl) = _validatePcsCrl(ca, crl);
+        
+        // attest crl timestamp
+        _storePcsValidity(key, uint64(currentCrl.validityNotBefore), uint64(currentCrl.validityNotAfter));
+        
         attestationId = _attestPcs(crl, hash, key);
 
         emit UpsertedPCSCollateral(ca, true);
     }
 
-    function _validatePcsCert(CA ca, bytes calldata cert) private view returns (bytes32 hash, bytes32 key) {
+    function _validatePcsCert(CA ca, bytes calldata cert) private view returns (bytes32 hash, bytes32 key, X509CertObj memory currentCert) {
         X509Helper x509Lib = X509Helper(x509);
-        X509CertObj memory currentCert = x509Lib.parseX509DER(cert);
+        currentCert = x509Lib.parseX509DER(cert);
 
         // Step 1: Check whether cert has expired
         bool validTimestamp = 
@@ -162,13 +177,10 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
         // Step 2: Rollback prevention: new certificate should not have an issued date
         // that is older than the existing certificate
         key = PCS_KEY(ca, false);
-        bytes memory existingData = _fetchDataFromResolver(key, false);
-        if (existingData.length > 0) {
-            (uint256 existingCertNotValidBefore, ) = x509Lib.getCertValidity(existingData);
-            bool outOfDate = existingCertNotValidBefore > currentCert.validityNotBefore;
-            if (outOfDate) {
-                revert Certificate_Out_Of_Date();
-            }
+        (uint64 existingCertNotValidBefore, ) = _loadPcsValidity(key);
+        bool outOfDate = existingCertNotValidBefore > currentCert.validityNotBefore;
+        if (outOfDate) {
+            revert Certificate_Out_Of_Date();
         }
 
         // Step 3: Check issuer and subject common names are valid
@@ -226,8 +238,8 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
         hash = keccak256(currentCert.tbs);
     }
 
-    function _validatePcsCrl(CA ca, bytes calldata crl) private view returns (bytes32 hash, bytes32 key) {
-        X509CRLObj memory currentCrl = crlLib.parseCRLDER(crl);
+    function _validatePcsCrl(CA ca, bytes calldata crl) private view returns (bytes32 hash, bytes32 key, X509CRLObj memory currentCrl) {
+        currentCrl = crlLib.parseCRLDER(crl);
         
         // Step 1: Check whether CRL has expired
         bool validTimestamp = 
@@ -240,13 +252,10 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
         // Step 2: Rollback prevention: new CRL should not have an issued date
         // that is older than the existing CRL
         key = PCS_KEY(ca, true);
-        bytes memory existingData = _fetchDataFromResolver(key, false);
-        if (existingData.length > 0) {
-            (uint256 existingCrlNotValidBefore, ) = crlLib.getCrlValidity(existingData);
-            bool outOfDate = existingCrlNotValidBefore > currentCrl.validityNotBefore;
-            if (outOfDate) {
-                revert Certificate_Out_Of_Date();
-            }
+        (uint64 existingCrlNotValidBefore, ) = _loadPcsValidity(key);
+        bool outOfDate = existingCrlNotValidBefore > currentCrl.validityNotBefore;
+        if (outOfDate) {
+            revert Certificate_Out_Of_Date();
         }
 
         // Step 3: Check CRL issuer
@@ -279,4 +288,8 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
             issuerCert = _fetchDataFromResolver(PCS_KEY(CA.ROOT, false), false);
         }
     }
+
+    function _storePcsValidity(bytes32 key, uint64 notValidBefore, uint64 notValidAfter) internal virtual;
+
+    function _loadPcsValidity(bytes32 key) internal view virtual returns (uint64 notValidBefore, uint64 notValidAfter);
 }


### PR DESCRIPTION
This PR adds an entry to store the validity timestamps (`issueDate` vs `nextUpdate`, or similar terms) for all collaterals.

All DAOs now have the `getCollateralValidity()` method that can be called by a reader to quickly determine the expiration status of the corresponding collateral, by providing the indexing key of the collateral.

This PR also partially addresses issue ID-5 regarding CRL expiration check.
