### PR TITLE
[TOB] Create2 Deployment

### DIFF
--- a/script/automata/DeployAutomataDao.s.sol
+++ b/script/automata/DeployAutomataDao.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "../utils/P256Configuration.sol";
+import "../utils/Salt.sol";
 
 import {AutomataDaoStorage} from "../../src/automata_pccs/shared/AutomataDaoStorage.sol";
 import {AutomataFmspcTcbDao} from "../../src/automata_pccs/AutomataFmspcTcbDao.sol";
@@ -17,6 +18,8 @@ contract DeployAutomataDao is P256Configuration {
     address enclaveIdentityHelper = vm.envAddress("ENCLAVE_IDENTITY_HELPER");
     address fmspcTcbHelper = vm.envAddress("FMSPC_TCB_HELPER");
 
+    address owner = vm.addr(privateKey);
+
     modifier broadcastKey(uint256 key) {
         vm.startBroadcast(key);
         _;
@@ -26,7 +29,7 @@ contract DeployAutomataDao is P256Configuration {
     function deployAll(bool shouldDeployStorage) public broadcastKey(privateKey) {
         AutomataDaoStorage pccsStorage;
         if (shouldDeployStorage) {
-            pccsStorage = new AutomataDaoStorage();
+            pccsStorage = new AutomataDaoStorage{salt: PCCS_STORAGE_SALT}(owner);
             console.log("AutomataDaoStorage deployed at ", address(pccsStorage));
         } else {
             address pccsStorageAddr = vm.envAddress("PCCS_STORAGE");
@@ -34,30 +37,30 @@ contract DeployAutomataDao is P256Configuration {
         }
 
         // Deploy PcsDao
-        AutomataPcsDao pcsDao = new AutomataPcsDao(address(pccsStorage), simulateVerify(), x509, x509Crl);
+        AutomataPcsDao pcsDao = new AutomataPcsDao{salt: PCS_DAO_SALT}(address(pccsStorage), simulateVerify(), x509, x509Crl);
         console.log("AutomataPcsDao deployed at: ", address(pcsDao));
 
         // Deploy PckDao
         AutomataPckDao pckDao =
-            new AutomataPckDao(address(pccsStorage), simulateVerify(), address(pcsDao), x509, x509Crl);
+            new AutomataPckDao{salt: PCK_DAO_SALT}(address(pccsStorage), simulateVerify(), address(pcsDao), x509, x509Crl);
         console.log("AutomataPckDao deployed at: ", address(pckDao));
 
         // Deploy EnclaveIdDao
-        AutomataEnclaveIdentityDao enclaveIdDao = new AutomataEnclaveIdentityDao(
+        AutomataEnclaveIdentityDao enclaveIdDao = new AutomataEnclaveIdentityDao{salt: ENCLAVE_ID_DAO_SALT}(
             address(pccsStorage), simulateVerify(), address(pcsDao), enclaveIdentityHelper, x509
         );
         console.log("AutomataEnclaveIdDao deployed at: ", address(enclaveIdDao));
 
         // Deploy FmspcDao
         AutomataFmspcTcbDao fmspcTcbDao =
-            new AutomataFmspcTcbDao(address(pccsStorage), simulateVerify(), address(pcsDao), fmspcTcbHelper, x509);
+            new AutomataFmspcTcbDao{salt: FMSPC_TCB_DAO_SALT}(address(pccsStorage), simulateVerify(), address(pcsDao), fmspcTcbHelper, x509);
         console.log("AutomataFmspcTcbDao deployed at: ", address(fmspcTcbDao));
 
         pccsStorage.updateDao(address(pcsDao), address(pckDao), address(fmspcTcbDao), address(enclaveIdDao));
     }
 
     function deployStorage() public broadcastKey(privateKey) {
-        AutomataDaoStorage pccsStorage = new AutomataDaoStorage();
+        AutomataDaoStorage pccsStorage = new AutomataDaoStorage{salt: PCCS_STORAGE_SALT}(owner);
 
         console.log("AutomataDaoStorage deployed at ", address(pccsStorage));
     }
@@ -65,7 +68,7 @@ contract DeployAutomataDao is P256Configuration {
     function deployPcs() public broadcastKey(privateKey) {
         address pccsStorageAddr = vm.envAddress("PCCS_STORAGE");
 
-        AutomataPcsDao pcsDao = new AutomataPcsDao(pccsStorageAddr, simulateVerify(), x509, x509Crl);
+        AutomataPcsDao pcsDao = new AutomataPcsDao{salt: PCS_DAO_SALT}(pccsStorageAddr, simulateVerify(), x509, x509Crl);
 
         console.log("AutomataPcsDao deployed at: ", address(pcsDao));
     }
@@ -74,7 +77,7 @@ contract DeployAutomataDao is P256Configuration {
         address pccsStorageAddr = vm.envAddress("PCCS_STORAGE");
         address pcsDaoAddr = vm.envAddress("PCS_DAO");
 
-        AutomataPckDao pckDao = new AutomataPckDao(pccsStorageAddr, simulateVerify(), pcsDaoAddr, x509, x509Crl);
+        AutomataPckDao pckDao = new AutomataPckDao{salt: PCK_DAO_SALT}(pccsStorageAddr, simulateVerify(), pcsDaoAddr, x509, x509Crl);
 
 
         console.log("AutomataPckDao deployed at: ", address(pckDao));
@@ -85,7 +88,7 @@ contract DeployAutomataDao is P256Configuration {
         address pcsDaoAddr = vm.envAddress("PCS_DAO");
 
         AutomataEnclaveIdentityDao enclaveIdDao =
-            new AutomataEnclaveIdentityDao(pccsStorageAddr, simulateVerify(), pcsDaoAddr, enclaveIdentityHelper, x509);
+            new AutomataEnclaveIdentityDao{salt: ENCLAVE_ID_DAO_SALT}(pccsStorageAddr, simulateVerify(), pcsDaoAddr, enclaveIdentityHelper, x509);
 
         console.log("AutomataEnclaveIdDao deployed at: ", address(enclaveIdDao));
     }
@@ -95,7 +98,7 @@ contract DeployAutomataDao is P256Configuration {
         address pcsDaoAddr = vm.envAddress("PCS_DAO");
 
         AutomataFmspcTcbDao fmspcTcbDao =
-            new AutomataFmspcTcbDao(pccsStorageAddr, simulateVerify(), pcsDaoAddr, fmspcTcbHelper, x509);
+            new AutomataFmspcTcbDao{salt: FMSPC_TCB_DAO_SALT}(pccsStorageAddr, simulateVerify(), pcsDaoAddr, fmspcTcbHelper, x509);
 
         console.log("AutomataFmspcTcbDao deployed at: ", address(fmspcTcbDao));
     }

--- a/script/helper/DeployHelpers.s.sol
+++ b/script/helper/DeployHelpers.s.sol
@@ -6,34 +6,35 @@ import "../../src/helpers/EnclaveIdentityHelper.sol";
 import "../../src/helpers/FmspcTcbHelper.sol";
 import "../../src/helpers/PCKHelper.sol";
 import "../../src/helpers/X509CRLHelper.sol";
+import "../utils/Salt.sol";
 
 contract DeployHelpers is Script {
     uint256 privateKey = vm.envUint("PRIVATE_KEY");
 
     function deployEnclaveIdentityHelper() public {
         vm.startBroadcast(privateKey);
-        EnclaveIdentityHelper enclaveIdentityHelper = new EnclaveIdentityHelper();
+        EnclaveIdentityHelper enclaveIdentityHelper = new EnclaveIdentityHelper{salt: ENCLAVE_IDENTITY_HELPER_SALT}();
         console.log("[LOG] EnclaveIdentityHelper: ", address(enclaveIdentityHelper));
         vm.stopBroadcast();
     }
 
     function deployFmspcTcbHelper() public {
         vm.startBroadcast(privateKey);
-        FmspcTcbHelper fmspcTcbHelper = new FmspcTcbHelper();
+        FmspcTcbHelper fmspcTcbHelper = new FmspcTcbHelper{salt: FMSPC_TCB_HELPER_SALT}();
         console.log("[LOG] FmspcTcbHelper: ", address(fmspcTcbHelper));
         vm.stopBroadcast();
     }
 
     function deployPckHelper() public {
         vm.startBroadcast(privateKey);
-        PCKHelper pckHelper = new PCKHelper();
+        PCKHelper pckHelper = new PCKHelper{salt: X509_HELPER_SALT}();
         console.log("[LOG] PCKHelper/X509Helper: ", address(pckHelper));
         vm.stopBroadcast();
     }
 
     function deployX509CrlHelper() public {
         vm.startBroadcast(privateKey);
-        X509CRLHelper x509Helper = new X509CRLHelper();
+        X509CRLHelper x509Helper = new X509CRLHelper{salt: X509_CRL_HELPER_SALT}();
         console.log("[LOG] X509CRLHelper: ", address(x509Helper));
         vm.stopBroadcast();
     }

--- a/script/utils/Salt.sol
+++ b/script/utils/Salt.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity >=0.8.0;
+
+bytes32 constant ENCLAVE_IDENTITY_HELPER_SALT = keccak256(bytes("ENCLAVE_IDENTITY_HELPER_SALT"));
+bytes32 constant FMSPC_TCB_HELPER_SALT = keccak256(bytes("FMSPC_TCB_HELPER_SALT"));
+bytes32 constant X509_HELPER_SALT = keccak256(bytes("X509_HELPER_SALT"));
+bytes32 constant X509_CRL_HELPER_SALT = keccak256(bytes("X509_CRL_HELPER_SALT"));
+
+bytes32 constant PCCS_STORAGE_SALT = keccak256(bytes("PCCS_STORAGE_SALT"));
+bytes32 constant ENCLAVE_ID_DAO_SALT = keccak256(bytes("ENCLAVE_ID_DAO_SALT"));
+bytes32 constant FMSPC_TCB_DAO_SALT = keccak256(bytes("FMSPC_TCB_DAO_SALT"));
+bytes32 constant PCK_DAO_SALT = keccak256(bytes("PCK_DAO_SALT"));
+bytes32 constant PCS_DAO_SALT = keccak256(bytes("PCS_DAO_SALT"));

--- a/src/automata_pccs/shared/AutomataDaoStorage.sol
+++ b/src/automata_pccs/shared/AutomataDaoStorage.sol
@@ -22,8 +22,8 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
         _;
     }
 
-    constructor() {
-        _initializeOwner(msg.sender);
+    constructor(address owner) {
+        _initializeOwner(owner);
 
         // adding address(0) as an authorized_reader to allow eth_call
         _authorized_readers[address(0)] = true;

--- a/test/TestSetupBase.t.sol
+++ b/test/TestSetupBase.t.sol
@@ -51,7 +51,7 @@ abstract contract TestSetupBase is Test {
         x509Lib = new PCKHelper();
 
         // deploy Automata PCCS
-        pccsStorage = new AutomataDaoStorage();
+        pccsStorage = new AutomataDaoStorage(admin);
 
         pcs = new AutomataPcsDao(address(pccsStorage), P256_VERIFIER, address(x509Lib), address(x509CrlLib));
 


### PR DESCRIPTION
- Provide salt in deployment scripts, to use CREATE2 for contract deployment.
- `AutomataDaoStorage` explicitly requires to pass an admin address upon initialization instead of using `msg.sender` as the admin address.