### PR TITLE
[TOB] Misc changes

### DIFF
--- a/src/automata_pccs/AutomataFmspcTcbDao.sol
+++ b/src/automata_pccs/AutomataFmspcTcbDao.sol
@@ -29,7 +29,7 @@ contract AutomataFmspcTcbDao is AutomataDaoBase, FmspcTcbDao {
         resolver.attest(tcbIssueEvaluationKey, abi.encode(slot), bytes32(0));
     }
 
-    /// TEMP it just reads from the separate attestation for now
+    /// TEMP it just reads from a separate attestation for now
     /// @dev we will have to come up with hacky low-level storage reads
     function _loadTcbInfoIssueEvaluation(bytes32 tcbKey) internal view override returns (uint64 issueDateTimestamp, uint32 evaluationDataNumber) {
         bytes32 tcbIssueEvaluationKey = _computeTcbIssueEvaluationKey(tcbKey);

--- a/src/automata_pccs/shared/AutomataDaoBase.sol
+++ b/src/automata_pccs/shared/AutomataDaoBase.sol
@@ -7,12 +7,12 @@ import {DaoBase} from "../../bases/DaoBase.sol";
 abstract contract AutomataDaoBase is DaoBase {
     
     /**
-     * @notice overridden the default method to check caller authorization
-     * this is added as a temporary measure to only allow read operations from
+     * @notice overrides the default _fetchDataFromResolver() method to allow
+     * custom logic implementation BEFORE fetching data from the resolver
+     * @notice this is added to allow read operations to be called from
      * the PCCSRouter contract (Learn more about PCCSRouter at
      * https://github.com/automata-network/automata-dcap-attestation/blob/DEV-3373/audit/contracts/PCCSRouter.sol)
      * 
-     * @notice this restriction may be removed in the future
      */
     function _onFetchDataFromResolver(bytes32 key, bool hash)
         internal

--- a/src/automata_pccs/shared/AutomataDaoStorage.sol
+++ b/src/automata_pccs/shared/AutomataDaoStorage.sol
@@ -75,7 +75,7 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
     }
 
     /**
-     * @notice In AutomataDaoStorage, we will simply assign the key as the attestationid of the collateral
+     * @notice the attestationId for collaterals will be simply derived from the key
      */
     function attest(bytes32 key, bytes calldata attData, bytes32 attDataHash)
         external
@@ -114,7 +114,7 @@ contract AutomataDaoStorage is AutomataTCBManager, IDaoAttestationResolver, Paus
 
     /**
      * @notice forms a mapping between (qeid, pceid) to tcbm
-     * @dev called AFTER the qeid, pceid and tcbm are all validated by the same PCK Certificate
+     * @dev called AFTER the qeid, pceid and tcbm have been validated by a corresponding PCK Certificate
      */
     function setTcbm(bytes16 qeid, bytes2 pceid, bytes18 tcbm) external onlyDao(msg.sender) {
         bytes32 k = keccak256(abi.encodePacked(qeid, pceid));

--- a/src/bases/DaoBase.sol
+++ b/src/bases/DaoBase.sol
@@ -24,7 +24,8 @@ abstract contract DaoBase {
      * @param key - mapped to a collateral as defined by individual data access objects (DAOs)
      */
     function getAttestedData(bytes32 key) external view returns (bytes memory attestationData) {
-        attestationData = _fetchDataFromResolver(key, false);
+        // invoke _onFetchDataFromResolver() here to invoke additional logic 
+        attestationData = _onFetchDataFromResolver(key, false);
     }
 
     /**

--- a/src/bases/DaoBase.sol
+++ b/src/bases/DaoBase.sol
@@ -28,8 +28,7 @@ abstract contract DaoBase {
     }
 
     /**
-     * @dev SHOULD store the hash of a collateral (e.g. X509 Cert, TCBInfo JSON etc) in the attestation registry
-     * as a separate attestation from the collateral data itself
+     * @notice fetches the hash of a collateral (e.g. X509 Cert, TCBInfo JSON etc) from the attestation registry
      */
     function getCollateralHash(bytes32 key) external view returns (bytes32 collateralHash) {
         bytes memory attestationData = _fetchDataFromResolver(key, true);

--- a/src/bases/EnclaveIdentityDao.sol
+++ b/src/bases/EnclaveIdentityDao.sol
@@ -10,7 +10,8 @@ import {DaoBase} from "./DaoBase.sol";
 import {SigVerifyBase} from "./SigVerifyBase.sol";
 import {PcsDao} from "./PcsDao.sol";
 
-/// @notice The on-chain schema for Identity.json is to store as ABI-encoded tuple of (EnclaveIdentityHelper.IdentityObj, string, bytes)
+/// @notice The on-chain schema for Identity.json is to store as ABI-encoded tuple of (EnclaveIdentityHelper.IdentityObj, EnclaveIdentityHelper.EnclaveIdentityJsonObj)
+/// @notice In other words, the tuple simply consists of the collateral in both parsed and string forms.
 /// @notice see {{ EnclaveIdentityHelper.IdentityObj }} for struct definition
 
 /**
@@ -74,8 +75,8 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
     {
         bytes memory attestedIdentityData = _onFetchDataFromResolver(ENCLAVE_ID_KEY(id, version), false);
         if (attestedIdentityData.length > 0) {
-            (, enclaveIdObj.identityStr, enclaveIdObj.signature) =
-                abi.decode(attestedIdentityData, (IdentityObj, string, bytes));
+            (, enclaveIdObj) =
+                abi.decode(attestedIdentityData, (IdentityObj, EnclaveIdentityJsonObj));
         }
     }
 
@@ -159,7 +160,7 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
             }
         }
 
-        reqData = abi.encode(identity, enclaveIdentityObj.identityStr, enclaveIdentityObj.signature);
+        reqData = abi.encode(identity, enclaveIdentityObj);
     }
 
     /**

--- a/src/bases/EnclaveIdentityDao.sol
+++ b/src/bases/EnclaveIdentityDao.sol
@@ -10,7 +10,7 @@ import {DaoBase} from "./DaoBase.sol";
 import {SigVerifyBase} from "./SigVerifyBase.sol";
 import {PcsDao} from "./PcsDao.sol";
 
-/// @notice The on-chain schema for Identity.json is stored as ABI-encoded tuple of (EnclaveIdentityHelper.IdentityObj, string, bytes)
+/// @notice The on-chain schema for Identity.json is to store as ABI-encoded tuple of (EnclaveIdentityHelper.IdentityObj, string, bytes)
 /// @notice see {{ EnclaveIdentityHelper.IdentityObj }} for struct definition
 
 /**
@@ -64,7 +64,8 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
      * @param id 0: QE; 1: QVE; 2: TD_QE
      * https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/39989a42bbbb0c968153a47254b6de79a27eb603/QuoteVerification/QVL/Src/AttestationLibrary/src/Verifiers/EnclaveIdentityV2.h#L49-L52
      * @param version the input version parameter (v3 or v4)
-     * @return enclaveIdObj See {EnclaveIdentityHelper.sol} to learn more about the structure definition
+     * @return enclaveIdObj - consisting of the Identity JSON string and the signature.
+     *  See {EnclaveIdentityHelper.sol} to learn more about the structure definition
      */
     function getEnclaveIdentity(uint256 id, uint256 version)
         external
@@ -83,7 +84,8 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
      * @param id 0: QE; 1: QVE; 2: TD_QE
      * https://github.com/intel/SGXDataCenterAttestationPrimitives/blob/39989a42bbbb0c968153a47254b6de79a27eb603/QuoteVerification/QVL/Src/AttestationLibrary/src/Verifiers/EnclaveIdentityV2.h#L49-L52
      * @param version the input version parameter (v3 or v4)
-     * @param enclaveIdentityObj See {EnclaveIdentityHelper.sol} to learn more about the structure definition
+     * @param enclaveIdentityObj enclaveIdObj - consisting of the Identity JSON string and the signature.
+     * See {EnclaveIdentityHelper.sol} to learn more about the structure definition
      */
     function upsertEnclaveIdentity(uint256 id, uint256 version, EnclaveIdentityJsonObj calldata enclaveIdentityObj)
         external
@@ -124,7 +126,7 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
     }
 
     /**
-     * @notice constructs the Identity.json attestation data
+     * @notice constructs the EnclaveIdentityHelper.IdentityObj attestation data
      */
     function _buildEnclaveIdentityAttestationRequest(
         uint256 id,

--- a/src/bases/FmspcTcbDao.sol
+++ b/src/bases/FmspcTcbDao.sol
@@ -17,10 +17,26 @@ import {
 } from "../helpers/FmspcTcbHelper.sol";
 
 /// @notice the on-chain schema of the attested data is dependent on the version of TCBInfo:
-/// @notice For TCBInfoV2, it consists of the ABI-encoded tuple of:
+/// @notice For TCBInfoV2, it consists of the ABI-encoded tuple of the following values:
+///
 /// @notice (TcbInfoBasic, TCBLevelsObj[], string tcbInfo, bytes signature)
+/// - ABI-encoded TcbHelper.TcbInfoBasic
+/// - serialized TCBLevelsObj bytes as implemented in TcbHelper.tcbLevelsObjToBytes()
+/// - ABI-encoded TcbHelper.TcbInfoJsonObj.tcbInfo JSON string
+/// - ABI-encoded TcbHelper.TcbInfoJsonObj.signature bytes
+///
 /// @notice For TCBInfoV3, it consists of the abi-encoded tuple of:
 /// @notice (TcbInfoBasic, TDXModule, TDXModuleIdentity[], TCBLevelsObj, string tcbInfo, bytes signature)
+/// - ABI-encoded TcbHelper.TcbInfoBasic
+/// - ABI-encoded TcbHelper.TDXModule
+/// - serialized TDXModuleIdentity bytes as implemented in TcbHelper.tdxModuleIdentityToBytes()
+/// - serialized TCBLevelsObj bytes as implemented in TcbHelper.tcbLevelsObjToBytes()
+/// - ABI-encoded TcbHelper.TcbInfoJsonObj.tcbInfo JSON string
+/// - ABI-encoded TcbHelper.TcbInfoJsonObj.signature bytes
+///
+/// @notice the serializers for TCBLevelsObj and TDXModuleIdentity[] are opted over ABI-encoding to significantly
+/// reduce gas costs.
+///
 /// @notice See {{ FmspcTcbHelper.sol }} to learn more about FMSPC TCB related struct definitions.
 
 /**

--- a/test/mock/MockTcbDao.sol
+++ b/test/mock/MockTcbDao.sol
@@ -23,7 +23,7 @@ contract MockTcbDao is FmspcTcbDao {
         valid = data.length > 0;
         if (valid) {
             bytes memory encodedLevels;
-            (tcbInfo, encodedLevels,,) = abi.decode(data, (TcbInfoBasic, bytes, string, bytes));
+            (tcbInfo, encodedLevels,) = abi.decode(data, (TcbInfoBasic, bytes, TcbInfoJsonObj));
             tcbLevelsV2 = _decodeTcbLevels(encodedLevels);
         }
     }
@@ -45,8 +45,8 @@ contract MockTcbDao is FmspcTcbDao {
         if (valid) {
             bytes memory encodedLevels;
             bytes memory encodedTdxModuleIdentities;
-            (tcbInfo, tdxModule, encodedTdxModuleIdentities, encodedLevels,,) =
-                abi.decode(data, (TcbInfoBasic, TDXModule, bytes, bytes, string, bytes));
+            (tcbInfo, tdxModule, encodedTdxModuleIdentities, encodedLevels,) =
+                abi.decode(data, (TcbInfoBasic, TDXModule, bytes, bytes, TcbInfoJsonObj));
             tcbLevelsV3 = _decodeTcbLevels(encodedLevels);
             if (encodedTdxModuleIdentities.length > 0) {
                 tdxModuleIdentities = _decodeTdxModuleIdentities(encodedTdxModuleIdentities);


### PR DESCRIPTION
This PR introduces the following changes:

- Clearer code commenting.
- Call `_onFetchDataFromResolver()` instead of `_fetchDataFromResolver()` for `DaoBase` getters, to invoke user-defined implementation logic. In our case, we wanted to perform the [caller authorization check](https://github.com/automata-network/automata-on-chain-pccs/blob/352f4f69ae270823531a877e670ce7bffbf6a2c0/src/automata_pccs/shared/AutomataDaoBase.sol#L24-L26) before returning the data.
- For both `EnclaveIdentityDAO` and `FmspcTcbDAO`, the JSON segment of the attestation data will now be encoded as a whole struct, rather than by its individual members. As recommended in Appendix D.