### PR TITLE
fix: typos in release notes and Solidity contract

### DIFF
--- a/releases/v1.0.0/NOTE.md
+++ b/releases/v1.0.0/NOTE.md
@@ -18,7 +18,7 @@ A production-ready release of the Automata Onchain PCCS smart contract, followin
  
 - Optimized FMSPC TCB parser by reducing unnecessary looping.
  
-- Introduced an interface standard for collateral storage known as the **Resolver**. The Resolver is a centralized location for invididual DAOs to write and for authorized callers to read collaterals.
+- Introduced an interface standard for collateral storage known as the **Resolver**. The Resolver is a centralized location for individual DAOs to write and for authorized callers to read collaterals.
  
 - Implemented collateral rollback protection:
   - Older (but unexpired) collaterals can no longer replace newer entries.

--- a/src/bases/EnclaveIdentityDao.sol
+++ b/src/bases/EnclaveIdentityDao.sol
@@ -244,7 +244,7 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
     /// @dev and the evaluation data number
     /// @dev this reduces the amount of data to read, when performing rollback check
     /// @dev which also allows any caller to check expiration of the Enclave Identity before loading the entire data
-    /// @dev the functions defined below can be overriden by the inheriting contract
+    /// @dev the functions defined below can be overridden by the inheriting contract
 
     function _storeEnclaveIdentityIssueEvaluation(
         bytes32 tcbKey,


### PR DESCRIPTION
- NOTE.md – fixed invididual → individual.

- EnclaveIdentityDao.sol – fixed overriden → overridden.