### PR TITLE
Remove unused TDX-related error declarations from FmspcTcbHelper

### DIFF
--- a/src/helpers/FmspcTcbHelper.sol
+++ b/src/helpers/FmspcTcbHelper.sol
@@ -97,8 +97,6 @@ contract FmspcTcbHelper {
     using BytesUtils for bytes;
 
     error TCBInfo_Invalid();
-    error TCB_TDX_Version_Invalid();
-    error TCB_TDX_ID_Invalid();
 
     /**
      * @notice this method generates content-specific hash


### PR DESCRIPTION
These errors (TCB_TDX_Version_Invalid, TCB_TDX_ID_Invalid) were never referenced anywhere in the codebase or tests. The helper consistently reverts with TCBInfo_Invalid for malformed or inconsistent inputs. Removing dead declarations reduces noise and does not alter behavior or the public API.