### PR TITLE
Fix PckDao issuer revocation check using wrong serial number

### DIFF
--- a/src/bases/PckDao.sol
+++ b/src/bases/PckDao.sol
@@ -356,9 +356,10 @@ abstract contract PckDao is DaoBase, SigVerifyBase {
             // check issuer evocation status
             bytes memory rootCrl = _fetchDataFromResolver(Pcs.PCS_KEY(CA.ROOT, true), false);
             if (rootCrl.length > 0) {
-                bool issuerRevoked = crlLib.serialNumberIsRevoked(pck.serialNumber, rootCrl);
+                uint256 issuerSerialNumber = pckLib.getSerialNumber(issuerCert);
+                bool issuerRevoked = crlLib.serialNumberIsRevoked(issuerSerialNumber, rootCrl);
                 if (issuerRevoked) {
-                    revert Issuer_Revoked(ca, pck.serialNumber);
+                    revert Issuer_Revoked(ca, issuerSerialNumber);
                 }
             }
 


### PR DESCRIPTION
## Summary
  - Fix `_validatePck()` in PckDao to use the intermediate CA certificate's serial number when checking the root CRL, instead of incorrectly using the PCK leaf certificate's serial number
  - Use the lightweight `pckLib.getSerialNumber()` to extract just the serial number from the issuer cert, avoiding the cost of a full `parseX509DER()` call

  ## Test plan
  - [x] Existing `forge test` suite passes (44/44)