### PR TITLE
fix: check staticcall return values in DAO revocation checks and reve…

### DIFF
--- a/src/bases/EnclaveIdentityDao.sol
+++ b/src/bases/EnclaveIdentityDao.sol
@@ -204,20 +204,22 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
             bytes memory rootCrl = _fetchDataFromResolver(Pcs.PCS_KEY(CA.ROOT, true), false);
             if (rootCrl.length > 0) {
                 // check revocation
-                (, bytes memory serialNumberData) = x509.staticcall(
+                (bool snSuccess, bytes memory serialNumberData) = x509.staticcall(
                     abi.encodeWithSelector(
                         0xb29b51cb, // X509Helper.getSerialNumber(bytes)
                         signingDer
                     )
                 );
+                require(snSuccess, "Failed to get serial number");
                 uint256 serialNumber = abi.decode(serialNumberData, (uint256));
-                (, bytes memory serialNumberRevokedData) = crlLibAddr.staticcall(
+                (bool crlSuccess, bytes memory serialNumberRevokedData) = crlLibAddr.staticcall(
                     abi.encodeWithSelector(
                         0xcedb9781, // X508CRLHelper.serialNumberIsRevoked(uint256,bytes)
                         serialNumber,
                         rootCrl
                     )
                 );
+                require(crlSuccess, "Failed to check CRL revocation");
                 bool revoked = abi.decode(serialNumberRevokedData, (bool));
                 if (revoked) {
                     revert TCB_Cert_Revoked(serialNumber);

--- a/src/bases/FmspcTcbDao.sol
+++ b/src/bases/FmspcTcbDao.sol
@@ -233,20 +233,22 @@ abstract contract FmspcTcbDao is DaoBase, SigVerifyBase {
             bytes memory rootCrl = _fetchDataFromResolver(Pcs.PCS_KEY(CA.ROOT, true), false);
             if (rootCrl.length > 0) {
                 // check revocation
-                (, bytes memory serialNumberData) = x509.staticcall(
+                (bool snSuccess, bytes memory serialNumberData) = x509.staticcall(
                     abi.encodeWithSelector(
                         0xb29b51cb, // X509Helper.getSerialNumber(bytes)
                         signingDer
                     )
                 );
+                require(snSuccess, "Failed to get serial number");
                 uint256 serialNumber = abi.decode(serialNumberData, (uint256));
-                (, bytes memory serialNumberRevokedData) = crlLibAddr.staticcall(
+                (bool crlSuccess, bytes memory serialNumberRevokedData) = crlLibAddr.staticcall(
                     abi.encodeWithSelector(
                         0xcedb9781, // X508CRLHelper.serialNumberIsRevoked(uint256,bytes)
                         serialNumber,
                         rootCrl
                     )
                 );
+                require(crlSuccess, "Failed to check CRL revocation");
                 bool revoked = abi.decode(serialNumberRevokedData, (bool));
                 if (revoked) {
                     revert TCB_Cert_Revoked(serialNumber);

--- a/src/bases/TcbEvalDao.sol
+++ b/src/bases/TcbEvalDao.sol
@@ -228,20 +228,22 @@ abstract contract TcbEvalDao is DaoBase, SigVerifyBase {
             bytes memory rootCrl = _fetchDataFromResolver(Pcs.PCS_KEY(CA.ROOT, true), false);
             if (rootCrl.length > 0) {
                 // Check revocation
-                (, bytes memory serialNumberData) = x509.staticcall(
+                (bool snSuccess, bytes memory serialNumberData) = x509.staticcall(
                     abi.encodeWithSelector(
                         0xb29b51cb, // X509Helper.getSerialNumber(bytes)
                         signingDer
                     )
                 );
+                require(snSuccess, "Failed to get serial number");
                 uint256 serialNumber = abi.decode(serialNumberData, (uint256));
-                (, bytes memory serialNumberRevokedData) = crlLibAddr.staticcall(
+                (bool crlSuccess, bytes memory serialNumberRevokedData) = crlLibAddr.staticcall(
                     abi.encodeWithSelector(
                         0xcedb9781, // X509CRLHelper.serialNumberIsRevoked(uint256,bytes)
                         serialNumber,
                         rootCrl
                     )
                 );
+                require(crlSuccess, "Failed to check CRL revocation");
                 bool revoked = abi.decode(serialNumberRevokedData, (bool));
                 if (revoked) {
                     revert TCB_Eval_Cert_Revoked(serialNumber);


### PR DESCRIPTION
## Summary

  - **Fix unchecked staticcall in DAO revocation checks**: `EnclaveIdentityDao`, `FmspcTcbDao`, and `TcbEvalDao` all call `X509Helper.getSerialNumber()` and `X509CRLHelper.serialNumberIsRevoked()` via `staticcall` during collateral upsert. The `success` return value was discarded. If either call failed (malformed DER, missing contract, insufficient gas), the code would decode undefined returndata and almost certainly skip revocation — a failed serial number lookup produces a garbage value unlikely to appear in the CRL. Now both calls `require(success)` and revert with descriptive messages.

  - **Fix silent empty-struct return in PCCSRouter**: `getQeIdentity`, `getFmspcTcbV2`, and `getFmspcTcbV3` returned zero-initialized structs when the versioned DAO address was set but the underlying data was empty or expired. Downstream verifiers could not distinguish this from legitimate data, risking incorrect attestation decisions. All three functions now revert with `QEIdentityExpiredOrNotFound` / `FmspcTcbExpiredOrNotFound` in every failure path, consistent with the existing behavior when no versioned DAO is configured.

  - **Issue 7 (readAttestation writer-only modifier)**: Documented as won't-fix. The `onlyDao` modifier on `readAttestation` checks `_authorized_writers` rather than `_authorized_readers`, but in the current architecture all reads go through DAO contract intermediaries (which are writers), so the system works correctly. Changing this would require a storage-layer permission model rework with unfavorable risk/benefit tradeoff.

  ## Test plan

  - [x] `forge test` passes in `automata-on-chain-pccs` (44/44)