### PR TITLE
Add collateral versioning to PCCS DAOs

### DIFF
--- a/src/bases/CollateralVersioning.sol
+++ b/src/bases/CollateralVersioning.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface ICollateralVersioning {
+    event CollateralVersionBumped(bytes32 indexed key, uint256 newVersion, uint256 timestamp);
+
+    function collateralVersion(bytes32 key) external view returns (uint256 version);
+
+    function hasChanged(bytes32 key, uint256 sinceVersion)
+        external
+        view
+        returns (bool changed, uint256 currentVersion);
+}
+
+abstract contract CollateralVersioningMixin is ICollateralVersioning {
+    mapping(bytes32 => uint256) private _versions;
+
+    function collateralVersion(bytes32 key) external view override returns (uint256 version) {
+        version = _versions[key];
+    }
+
+    function hasChanged(bytes32 key, uint256 sinceVersion)
+        external
+        view
+        override
+        returns (bool changed, uint256 currentVersion)
+    {
+        currentVersion = _versions[key];
+        changed = currentVersion > sinceVersion;
+    }
+
+    function _bumpVersion(bytes32 key) internal {
+        uint256 newVersion;
+        unchecked {
+            newVersion = _versions[key] + 1;
+        }
+        _versions[key] = newVersion;
+        emit CollateralVersionBumped(key, newVersion, block.timestamp);
+    }
+}

--- a/src/bases/EnclaveIdentityDao.sol
+++ b/src/bases/EnclaveIdentityDao.sol
@@ -9,6 +9,7 @@ import {
 import {DaoBase} from "./DaoBase.sol";
 import {SigVerifyBase} from "./SigVerifyBase.sol";
 import {PcsDao} from "./PcsDao.sol";
+import {CollateralVersioningMixin} from "./CollateralVersioning.sol";
 
 /// @notice The on-chain schema for Identity.json is to store as ABI-encoded tuple of (EnclaveIdentityHelper.IdentityObj, EnclaveIdentityHelper.EnclaveIdentityJsonObj)
 /// @notice In other words, the tuple simply consists of the collateral in both parsed and string forms.
@@ -21,7 +22,7 @@ import {PcsDao} from "./PcsDao.sol";
  * @dev should extends this contract and use the provided read/write methods to interact with
  * Identity.json data published on-chain.
  */
-abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
+abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase, CollateralVersioningMixin {
     PcsDao public Pcs;
     EnclaveIdentityHelper public EnclaveIdentityLib;
     address public crlLibAddr;
@@ -127,6 +128,7 @@ abstract contract EnclaveIdentityDao is DaoBase, SigVerifyBase {
         attestationId = _attestEnclaveIdentity(req, hash, key);
 
         _storeIdentityContentHash(key, identityContentHash);
+        _bumpVersion(key);
 
         emit UpsertedEnclaveIdentity(id, version);
     }

--- a/src/bases/FmspcTcbDao.sol
+++ b/src/bases/FmspcTcbDao.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import {PcsDao} from "./PcsDao.sol";
 import {DaoBase} from "./DaoBase.sol";
 import {SigVerifyBase} from "./SigVerifyBase.sol";
+import {CollateralVersioningMixin} from "./CollateralVersioning.sol";
 
 import {CA} from "../Common.sol";
 import {
@@ -44,7 +45,7 @@ import {
  * @dev should extends this contract and use the provided read/write methods to interact with TCBInfo JSON
  * data published on-chain.
  */
-abstract contract FmspcTcbDao is DaoBase, SigVerifyBase {
+abstract contract FmspcTcbDao is DaoBase, SigVerifyBase, CollateralVersioningMixin {
     PcsDao public Pcs;
     FmspcTcbHelper public FmspcTcbLib;
     address public crlLibAddr;
@@ -156,6 +157,7 @@ abstract contract FmspcTcbDao is DaoBase, SigVerifyBase {
 
         _storeTcbInfoIssueEvaluation(key, tcbInfo.issueDate, tcbInfo.nextUpdate, tcbInfo.evaluationDataNumber);
         _storeFmspcTcbContentHash(key, contentHash);
+        _bumpVersion(key);
         emit UpsertedFmpscTcb(uint8(tcbInfo.id), tcbInfo.fmspc, tcbInfo.version);
     }
 

--- a/src/bases/PcsDao.sol
+++ b/src/bases/PcsDao.sol
@@ -7,6 +7,7 @@ import {X509CRLHelper, X509CRLObj} from "../helpers/X509CRLHelper.sol";
 
 import {DaoBase} from "./DaoBase.sol";
 import {SigVerifyBase} from "./SigVerifyBase.sol";
+import {CollateralVersioningMixin} from "./CollateralVersioning.sol";
 
 import {LibString} from "solady/utils/LibString.sol";
 
@@ -21,7 +22,7 @@ import {LibString} from "solady/utils/LibString.sol";
  * @notice This contract is heavily inspired by Sections 4.2.5 and 4.2.6 in the Intel SGX PCCS Design Guideline
  * https://download.01.org/intel-sgx/sgx-dcap/1.19/linux/docs/SGX_DCAP_Caching_Service_Design_Guide.pdf
  */
-abstract contract PcsDao is DaoBase, SigVerifyBase {
+abstract contract PcsDao is DaoBase, SigVerifyBase, CollateralVersioningMixin {
     using LibString for string;
 
     X509CRLHelper public crlLib;
@@ -123,6 +124,7 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
         _storePcsValidity(key, uint64(parsedX509Cert.validityNotBefore), uint64(parsedX509Cert.validityNotAfter));
 
         attestationId = _attestPcs(cert, hash, key);
+        _bumpVersion(key);
 
         emit UpsertedPCSCollateral(ca, false);
     }
@@ -162,6 +164,7 @@ abstract contract PcsDao is DaoBase, SigVerifyBase {
         _storePcsValidity(key, uint64(currentCrl.validityNotBefore), uint64(currentCrl.validityNotAfter));
 
         attestationId = _attestPcs(crl, hash, key);
+        _bumpVersion(key);
 
         emit UpsertedPCSCollateral(ca, true);
     }

--- a/src/bases/TcbEvalDao.sol
+++ b/src/bases/TcbEvalDao.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import {PcsDao} from "./PcsDao.sol";
 import {DaoBase} from "./DaoBase.sol";
 import {SigVerifyBase} from "./SigVerifyBase.sol";
+import {CollateralVersioningMixin} from "./CollateralVersioning.sol";
 
 import {CA} from "../Common.sol";
 import {TcbEvalHelper, TcbEvalJsonObj, TcbEvalDataBasic, TcbEvalNumber, TcbId} from "../helpers/TcbEvalHelper.sol";
@@ -21,7 +22,7 @@ import {TcbEvalHelper, TcbEvalJsonObj, TcbEvalDataBasic, TcbEvalNumber, TcbId} f
  * @dev should extends this contract and use the provided read/write methods to interact with TCB Evaluation Data Numbers JSON
  * data published on-chain.
  */
-abstract contract TcbEvalDao is DaoBase, SigVerifyBase {
+abstract contract TcbEvalDao is DaoBase, SigVerifyBase, CollateralVersioningMixin {
     PcsDao public Pcs;
     TcbEvalHelper public TcbEvalLib;
     address public crlLibAddr;
@@ -139,6 +140,7 @@ abstract contract TcbEvalDao is DaoBase, SigVerifyBase {
         attestationId = _attestTcbEval(req, hash, key);
 
         _storeTcbEvalIssueData(key, tcbEvalData.issueDate, tcbEvalData.nextUpdate);
+        _bumpVersion(key);
         emit UpsertedTcbEval(uint8(tcbEvalData.id));
     }
 

--- a/test/eval/AutomataTcbEvalDaoTest.t.sol
+++ b/test/eval/AutomataTcbEvalDaoTest.t.sol
@@ -72,8 +72,16 @@ contract AutomataTcbEvalDaoTest is PCSSetupBase {
         vm.startPrank(admin);
         
         TcbEvalJsonObj memory fetched = tcbEvalDao.getTcbEvaluationObject(TcbId.SGX);
+        bytes32 key = tcbEvalDao.TCB_EVAL_KEY(TcbId.SGX);
+        (bool changedFromZero, uint256 versionFromZero) = tcbEvalDao.hasChanged(key, 0);
+        (bool changedFromCurrent, uint256 currentVersion) = tcbEvalDao.hasChanged(key, 1);
         assertEq(fetched.tcbEvaluationDataNumbers, tcbEvalJsonObj.tcbEvaluationDataNumbers);
         assertEq(fetched.signature, tcbEvalJsonObj.signature);
+        assertEq(tcbEvalDao.collateralVersion(key), 1);
+        assertTrue(changedFromZero);
+        assertEq(versionFromZero, 1);
+        assertFalse(changedFromCurrent);
+        assertEq(currentVersion, 1);
 
 
         // test loading all tcb evaluation numbers

--- a/test/identity/AutomataEnclaveIdentityVersionedTest.t.sol
+++ b/test/identity/AutomataEnclaveIdentityVersionedTest.t.sol
@@ -78,6 +78,9 @@ contract AutomataEnclaveIdentityDaoVersionedTest is PCSSetupBase, IdentityConsta
         vm.prank(admin);
         EnclaveIdentityJsonObj memory retrievedEnclaveIdentityObjFromVersioned =
             enclaveIdDaoVersioned.getEnclaveIdentity(0, 3);
+        bytes32 key = enclaveIdDaoVersioned.ENCLAVE_ID_KEY(0, 3);
+        (bool changedFromZero, uint256 versionFromZero) = enclaveIdDaoVersioned.hasChanged(key, 0);
+        (bool changedFromCurrent, uint256 currentVersion) = enclaveIdDaoVersioned.hasChanged(key, 1);
         assertEq(
             retrievedEnclaveIdentityObjFromVersioned.identityStr,
             identity,
@@ -88,6 +91,11 @@ contract AutomataEnclaveIdentityDaoVersionedTest is PCSSetupBase, IdentityConsta
             sig,
             "Retrieved signature does not match the expected value"
         );
+        assertEq(enclaveIdDaoVersioned.collateralVersion(key), 1);
+        assertTrue(changedFromZero);
+        assertEq(versionFromZero, 1);
+        assertFalse(changedFromCurrent);
+        assertEq(currentVersion, 1);
 
         vm.prank(admin);
         // it should not override collaterals maintained by the community dao

--- a/test/pcs/AutomataPcsDaoTest.t.sol
+++ b/test/pcs/AutomataPcsDaoTest.t.sol
@@ -101,4 +101,26 @@ contract AutomataPcsDaoTest is PCSSetupBase {
         vm.expectRevert(abi.encodeWithSelector(DaoBase.Duplicate_Collateral.selector));
         pcs.upsertPcsCertificates(CA.PLATFORM, platformDer);
     }
+
+    function testCollateralVersions() public {
+        bytes32 rootCertKey = pcs.PCS_KEY(CA.ROOT, false);
+        bytes32 rootCrlKey = pcs.PCS_KEY(CA.ROOT, true);
+        bytes32 platformCertKey = pcs.PCS_KEY(CA.PLATFORM, false);
+        (bool rootCertChanged, uint256 rootCertVersion) = pcs.hasChanged(rootCertKey, 0);
+        (bool rootCrlChanged, uint256 rootCrlVersion) = pcs.hasChanged(rootCrlKey, 0);
+        (bool platformChanged, uint256 platformVersion) = pcs.hasChanged(platformCertKey, 0);
+        (bool rootCertChangedFromCurrent, uint256 rootCertCurrent) = pcs.hasChanged(rootCertKey, 1);
+
+        assertEq(pcs.collateralVersion(rootCertKey), 1);
+        assertEq(pcs.collateralVersion(rootCrlKey), 1);
+        assertEq(pcs.collateralVersion(platformCertKey), 1);
+        assertTrue(rootCertChanged);
+        assertEq(rootCertVersion, 1);
+        assertTrue(rootCrlChanged);
+        assertEq(rootCrlVersion, 1);
+        assertTrue(platformChanged);
+        assertEq(platformVersion, 1);
+        assertFalse(rootCertChangedFromCurrent);
+        assertEq(rootCertCurrent, 1);
+    }
 }

--- a/test/tcb/AutomataTcbDaoVersionedTest.t.sol
+++ b/test/tcb/AutomataTcbDaoVersionedTest.t.sol
@@ -66,9 +66,17 @@ contract AutomataFmspcTcbDaoVersionedTest is PCSSetupBase, TCBConstants {
 
         TcbInfoJsonObj memory fetchedTcbInfoObjFromVersioned =
             fmspcTcbDaoVersioned.getTcbInfo(0, "00A067110000", 2);
+        bytes32 key = fmspcTcbDaoVersioned.FMSPC_TCB_KEY(0, bytes6(uint48(0x00A067110000)), 2);
+        (bool changedFromZero, uint256 versionFromZero) = fmspcTcbDaoVersioned.hasChanged(key, 0);
+        (bool changedFromCurrent, uint256 currentVersion) = fmspcTcbDaoVersioned.hasChanged(key, 1);
 
         assertEq(fetchedTcbInfoObjFromVersioned.tcbInfoStr, tcbInfoStr);
         assertEq(fetchedTcbInfoObjFromVersioned.signature, sig);
+        assertEq(fmspcTcbDaoVersioned.collateralVersion(key), 1);
+        assertTrue(changedFromZero);
+        assertEq(versionFromZero, 1);
+        assertFalse(changedFromCurrent);
+        assertEq(currentVersion, 1);
 
         TcbInfoJsonObj memory fetchedTcbInfoObjFromCommunity =
             fmspcTcbDao.getTcbInfo(0, "00A067110000", 2);


### PR DESCRIPTION
## Summary
- add `CollateralVersioningMixin` and `ICollateralVersioning`
- bump per-collateral version in `FmspcTcbDao`, `EnclaveIdentityDao`, `PcsDao`, and `TcbEvalDao` on successful upsert
- add focused tests for version read and change detection in DAO suites

## Validation
- `forge test` (full suite)
- includes new assertions for `collateralVersion` and `hasChanged`
